### PR TITLE
Upgrade cassandra-driver-core to 3.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.trino.cassandra</groupId>
     <artifactId>cassandra-driver</artifactId>
-    <version>3.1.4-4-SNAPSHOT</version>
+    <version>3.10.2-1-SNAPSHOT</version>
 
     <name>cassandra-driver</name>
     <description>Shaded version of DataStax Java Driver for Apache Cassandra</description>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>3.1.4</version>
+            <version>3.10.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
I was preparing for https://github.com/trinodb/trino/issues/10276, but the current version isn't compatible with ScyllaDB's driver.
https://mvnrepository.com/artifact/com.scylladb/scylla-driver-core
