### PR TITLE
Migrate to GitHub Actions from Travis CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java-version:
+          - 11
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Maven Install
+        run: mvn install -B -V -DskipTests -Dair.check.skip-all
+      - name: Maven Tests
+        run: mvn install -B

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: java


### PR DESCRIPTION
The `ci.yml` is equivalent to https://github.com/trinodb/trino-yugabyte-driver/blob/main/.github/workflows/ci.yml on the part of `on`. 